### PR TITLE
Update suggested helix editor configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,21 @@ This repo implements a VSCode client extension that is published to the [marketp
 
 ```toml
 [[language]]
-name = "algebraic-data-language"
-scope = "source.adl"
+name = "adl"
 language-id = "adl"
-file-types = ["adl", "adl-cpp", "adl-hs", "adl-java", "adl-hs", "adl-rs", "adl-ts"]
-roots = [".git"]
-comment-tokens = ["//", "///", "//!"]
+scope = "source.adl"
+injection-regex = "adl"
+file-types = ["adl", "adl-cpp", "adl-hs", "adl-java", "adl-rs", "adl-ts"]
+comment-token = "//"
+indent = { tab-width = 2, unit = "  " }
+roots = []
 language-servers = ["adl-lsp"]
 workspace-lsp-roots = ["adl"]
+
+[language.auto-pairs]
+'"' = '"'
+'{' = '}'
+'<' = '>'
 
 [language-server.adl-lsp]
 command = "adl-lsp"


### PR DESCRIPTION
Making it more consistent with the adl configuration already baked into the helix editor:

https://github.com/helix-editor/helix/blob/171dfc60e5cda8f9fb6c4f662872f35bbe864a53/languages.toml#L3893

ultimately all this config would be baked into the helix editor, such that having `adl-lsp` on the path would be sufficient for full functionality